### PR TITLE
Don't automatically enable verbose makefiles.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,5 @@
 cmake_minimum_required(VERSION 3.5)
 project(rosidl_dynamic_typesupport_fastrtps)
-set(CMAKE_VERBOSE_MAKEFILE ON)
 
 
 # COMPILER SETTINGS ================================================================================
@@ -17,8 +16,6 @@ endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
-
-set(CMAKE_VERBOSE_MAKEFILE ON)
 
 
 # DEPS =============================================================================================


### PR DESCRIPTION
## Description

follow @clalancette 's fix on https://github.com/ros2/rosidl_dynamic_typesupport/pull/17

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes # (issue)

### Is this user-facing behavior change?

Not really for the user.

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
